### PR TITLE
cat21 updates

### DIFF
--- a/asterix4py/AsterixParser.py
+++ b/asterix4py/AsterixParser.py
@@ -18,7 +18,7 @@ astXmlFiles = {
     10: 'asterix_cat010_1_1.xml',
     19: 'asterix_cat019_1_2.xml',
     20: 'asterix_cat020_1_7.xml',
-    21: 'asterix_cat021_1_8.xml',
+    21: 'asterix_cat021_2_2.xml',
     23: 'asterix_cat023_1_2.xml',
     30: 'asterix_cat030_6_2.xml',
     31: 'asterix_cat031_6_2.xml',
@@ -120,6 +120,8 @@ class AsterixParser:
                             r = self.decode_variable(cn)
                         elif cn.nodeName == 'Compound':
                             r = self.decode_compound(cn)
+                        elif cn.nodeName == 'Explicit':
+                            r = self.decode_explicit(cn)
 
                         if r:
                             self.decoded.update({itemid: r})
@@ -259,7 +261,16 @@ class AsterixParser:
             results.update(r)
 
         return results
-
+    
+    def decode_explicit(self, datafield):
+        length = self.bytes[self.p]
+        bit_name = datafield.getElementsByTagName('Bits')[0].getElementsByTagName('BitsShortName')[0].firstChild.nodeValue
+        results = {}  # Special and reserved fields in CAT21 aren't decoded so just return hex string
+        results[bit_name] = self.bytes[self.p+1:self.p + length].hex()
+        self.p += length
+        
+        return results
+        
     """convert binary value to 8 bit ascii text string"""
 
     def bits_to_ascii(self, bitvalue):

--- a/asterix4py/config/asterix_cat021_1_8.xml
+++ b/asterix4py/config/asterix_cat021_1_8.xml
@@ -8,6 +8,7 @@
     Author:   B.Bertrand
     Created:  2012-12-17
 	Modified:  28.4.2014. (dsalantic) Special characters removed from BitsShortName, some BitsShortName renamed, tabs aligned
+	Modified:  14.9.2020. (drumlight) Correct definition of RE-bit in I021/160
 
 -->
 
@@ -864,7 +865,7 @@
         <DataItemDefinition>Ground Speed and Track Angle elements of Ground Vector.</DataItemDefinition>
         <DataItemFormat desc="Four-Octet fixed length data item.">
             <Fixed length="4">
-                <Bits bit="16">
+                <Bits bit="32">
                     <BitsShortName>RE</BitsShortName>
                     <BitsName>Range Exceeded Indicator</BitsName>
                     <BitsValue val="0">Value in defined range</BitsValue>

--- a/asterix4py/config/asterix_cat021_2_2.xml
+++ b/asterix4py/config/asterix_cat021_2_2.xml
@@ -1,0 +1,1709 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Category SYSTEM "asterix.dtd">
+
+<!--
+
+    Asterix Category 021 v2.2 definition
+
+    Author:   B.Bertrand
+    Created:  2012-12-17
+	Modified:  28.4.2014. (dsalantic) Special characters removed from BitsShortName, some BitsShortName renamed, tabs aligned
+    Modified:  14.9.2020 (drumlight) Updated to v2.2 definitions
+
+-->
+
+<Category id="021" name="Surveillance Data Exchange - Part 12 ADS-B Reports" ver="2.2">
+    <DataItem id="008" rule="optional">
+        <DataItemName>Aircraft Operational Status</DataItemName>
+        <DataItemDefinition>Identification of the operational services available in the aircraft while airborne.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>RA</BitsShortName>
+                    <BitsName>TCAS Resolution Advisory active</BitsName>
+                    <BitsValue val="0">TCAS II or ACAS RA not active</BitsValue>
+                    <BitsValue val="1">TCAS RA active</BitsValue>
+                </Bits>
+                <Bits from="7" to="6">
+                    <BitsShortName>TC</BitsShortName>
+                    <BitsName>Target Change Report Capability</BitsName>
+                    <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
+                    <BitsValue val="1">support for TC+0 reports only</BitsValue>
+                    <BitsValue val="2">support for multiple TC reports</BitsValue>
+                    <BitsValue val="3">reserved</BitsValue>
+                </Bits>
+                <Bits bit="5">
+                    <BitsShortName>TS</BitsShortName>
+                    <BitsName>Target State Report Capability</BitsName>
+                    <BitsValue val="0">no capability to support Target State Reports</BitsValue>
+                    <BitsValue val="1">capable of supporting target State Reports</BitsValue>
+                </Bits>
+                <Bits bit="4">
+                    <BitsShortName>ARV</BitsShortName>
+                    <BitsName>Air-Referenced Velocity Report Capability</BitsName>
+                    <BitsValue val="0">no capability to generate ARV-reports</BitsValue>
+                    <BitsValue val="1">capable of generate ARV-reports</BitsValue>
+                </Bits>
+                <Bits bit="3">
+                    <BitsShortName>CDTI_A</BitsShortName>
+                    <BitsName>Cockpit Display of Traffic Information airborne</BitsName>
+                    <BitsValue val="0">CDTI not operational</BitsValue>
+                    <BitsValue val="1">CDTI operational</BitsValue>
+                </Bits>
+                <Bits bit="2">
+                    <BitsShortName>not_TCAS</BitsShortName>
+                    <BitsName>TCAS System Status</BitsName>
+                    <BitsValue val="0">TCAS operational or unknown</BitsValue>
+                    <BitsValue val="1">TCAS not installed or not operational</BitsValue>
+                </Bits>
+                <Bits bit="1">
+                    <BitsShortName>SA</BitsShortName>
+                    <BitsName>Single Antenna</BitsName>
+                    <BitsValue val="0">Antenna Diversity</BitsValue>
+                    <BitsValue val="1">Single Antenna Only</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="010" rule="mandatory">
+        <DataItemName>Data Source Identification</DataItemName>
+        <DataItemDefinition>Identification of the ADS-B station providing information.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="9">
+                    <BitsShortName>SAC</BitsShortName>
+                    <BitsName>System Area Code</BitsName>
+                </Bits>
+                <Bits from="8" to="1">
+                    <BitsShortName>SIC</BitsShortName>
+                    <BitsName>System Identification Code</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="015" rule="optional">
+        <DataItemName>Service Identification</DataItemName>
+        <DataItemDefinition>Identification of the service provided to one or more users.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>id</BitsShortName>
+                    <BitsName>Service Identification</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="016" rule="optional">
+        <DataItemName>Service Management</DataItemName>
+        <DataItemDefinition>Identification of services offered by a ground station (identified by a SIC code).</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>RP</BitsShortName>
+                    <BitsName>Report Period</BitsName>
+                    <BitsUnit scale="0.5" min="0" max="127.5">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. This item contains the same information as item I023/101 in ASTERIX category 023 [Ref. 3]. Since not all service users receive category 023 data, this information has to be conveyed in category 021 as well. 2. If this item is due to be sent according to the encoding rule above, it shall be sent with the next target report</DataItemNote>
+    </DataItem>
+
+    <DataItem id="020" rule="optional">
+        <DataItemName>Emitter Category</DataItemName>
+        <DataItemDefinition>Characteristics of the originating ADS-B unit.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>ECAT</BitsShortName>
+                    <BitsName>Emitter Category</BitsName>
+                    <BitsValue val="0">No ADS-B Emitter Category Information</BitsValue>
+                    <BitsValue val="1">light aircraft &lt;= 15500 lbs</BitsValue>
+                    <BitsValue val="2">15500 lbs &lt; small aircraft &lt; 75000 lbs</BitsValue>
+                    <BitsValue val="3">75000 lbs &lt; medium a/c &lt; 300000 lbs</BitsValue>
+                    <BitsValue val="4">High Vortex Large</BitsValue>
+                    <BitsValue val="5">300000 lbs &lt;= heavy aircraft</BitsValue>
+                    <BitsValue val="6">highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise)</BitsValue>
+                    <BitsValue val="7">reserved</BitsValue>
+                    <BitsValue val="8">reserved</BitsValue>
+                    <BitsValue val="9">reserved</BitsValue>
+                    <BitsValue val="10">rotocraft</BitsValue>
+                    <BitsValue val="11">glider / sailplane</BitsValue>
+                    <BitsValue val="12">lighter-than-air</BitsValue>
+                    <BitsValue val="13">unmanned aerial vehicle</BitsValue>
+                    <BitsValue val="14">space / transatmospheric vehicle</BitsValue>
+                    <BitsValue val="15">ultralight / handglider / paraglider</BitsValue>
+                    <BitsValue val="16">parachutist / skydiver</BitsValue>
+                    <BitsValue val="17">reserved</BitsValue>
+                    <BitsValue val="18">reserved</BitsValue>
+                    <BitsValue val="19">reserved</BitsValue>
+                    <BitsValue val="20">surface emergency vehicle</BitsValue>
+                    <BitsValue val="21">surface service vehicle</BitsValue>
+                    <BitsValue val="22">fixed ground or tethered obstruction</BitsValue>
+                    <BitsValue val="23">cluster obstacle</BitsValue>
+                    <BitsValue val="24">line obstacle</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="040" rule="mandatory">
+        <DataItemName>Target Report Descriptor</DataItemName>
+        <DataItemDefinition>Type and characteristics of the data as transmitted by a system.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one octet, followed by one-octet extensions as necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>ATP</BitsShortName>
+                        <BitsName>Address Type</BitsName>
+                        <BitsValue val="0">24-Bit ICAO address</BitsValue>
+                        <BitsValue val="1">Duplicate address</BitsValue>
+                        <BitsValue val="2">Surface vehicle address</BitsValue>
+                        <BitsValue val="3">Anonymous address</BitsValue>
+                        <BitsValue val="4">Reserved for future use</BitsValue>
+                        <BitsValue val="5">Reserved for future use</BitsValue>
+                        <BitsValue val="6">Reserved for future use</BitsValue>
+                        <BitsValue val="7">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>ARC</BitsShortName>
+                        <BitsName>Altitude Reporting Capability</BitsName>
+                        <BitsValue val="0">25 ft</BitsValue>
+                        <BitsValue val="1">100 ft</BitsValue>
+                        <BitsValue val="2">Unknown</BitsValue>
+                        <BitsValue val="3">Invalid</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RC</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Range Check passed, CPR Validation pending</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RAB</BitsShortName>
+                        <BitsName>Report Type</BitsName>
+                        <BitsValue val="0">Report from target transponder</BitsValue>
+                        <BitsValue val="1">Report from field monitor (fixed transponder)</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of item</BitsValue>
+                        <BitsValue val="1">Entension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>DCR</BitsShortName>
+                        <BitsName>Differential Correction</BitsName>
+                        <BitsValue val="0">No differential correction (ADS-B)</BitsValue>
+                        <BitsValue val="1">Differential correction (ADS-B)</BitsValue>
+                    </Bits>
+                    <Bits bit="7">
+                        <BitsShortName>GBS</BitsShortName>
+                        <BitsName>Ground Bit Setting</BitsName>
+                        <BitsValue val="0">Ground Bit not set</BitsValue>
+                        <BitsValue val="1">Ground Bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SIM</BitsShortName>
+                        <BitsName>Simulated Target</BitsName>
+                        <BitsValue val="0">Actual target report</BitsValue>
+                        <BitsValue val="1">Simulated target report</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>TST</BitsShortName>
+                        <BitsName>Test Target</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Test Target</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>SAA</BitsShortName>
+                        <BitsName>Selected Altitude Available</BitsName>
+                        <BitsValue val="0">Equipment capable to provide Selected Altitude</BitsValue>
+                        <BitsValue val="1">Equipment not capable to provide Selected Altitude</BitsValue>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>CL</BitsShortName>
+                        <BitsName>Confidence Level</BitsName>
+                        <BitsValue val="0">Report valid</BitsValue>
+                        <BitsValue val="1">Report suspect</BitsValue>
+                        <BitsValue val="2">No information</BitsValue>
+                        <BitsValue val="3">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of item</BitsValue>
+                        <BitsValue val="1">Entension into second extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>IPC</BitsShortName>
+                        <BitsName>Independent Position Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">failed</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>NOGO</BitsShortName>
+                        <BitsName>No-go Bit Status</BitsName>
+                        <BitsValue val="0">NOGO-bit not set</BitsValue>
+                        <BitsValue val="1">NOGO-bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>CPR</BitsShortName>
+                        <BitsName>Compact Position Reporting</BitsName>
+                        <BitsValue val="0">CPR Validation correct</BitsValue>
+                        <BitsValue val="1">CPR Validation failed</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>LDPJ</BitsShortName>
+                        <BitsName>Local Decoding Position Jump</BitsName>
+                        <BitsValue val="0">LDPJ not detected</BitsValue>
+                        <BitsValue val="1">LDPJ detected</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RCF</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">Range Check failed</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of data item</BitsValue>
+                        <BitsValue val="1">Entension into third extent</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+        <DataItemNote>1. Bit 3 indicates that the position reported by the target is within a credible range from the ground station. The range check is followed by the CPR validation to ensure that global and local position decoding both indicate valid position information. Bit 3=1 indicates that the range check was done, but the CPR validation is not yet completed. Once CPR validation is completed, Bit 3 will be reset to 0. 2. The second extension signals the reasons for which the report has been indicated as suspect (indication Confidence Level (CL) in the first extension). Bit 2 indicates that the Range Check failed, i.e. the target is reported outside the credible range for the Ground Station. For operational users such a target will be suppressed. In services used for monitoring the Ground Station, the target will be transmitted with bit 2 indicating the fault condition. 3. Bit 5 represents the setting of the GO/NOGO-bit as defined in item I023/100 of category 023 [Ref. 3]. 4. Bits 8/6 are reserved for future use.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="070" rule="optional">
+        <DataItemName>Mode 3/A Code in Octal Representation</DataItemName>
+        <DataItemDefinition>Mode-3/A code converted into octal representation.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1" encode="octal">
+					<BitsShortName>Mode3A</BitsShortName>
+                    <BitsName>Mode-3/A reply in octal</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="071" rule="optional">
+        <DataItemName>Time of Applicability for Position</DataItemName>
+        <DataItemDefinition>Time of applicability of the reported position, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_applicability_position</BitsShortName>
+                    <BitsName>Time of Applicability of Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. The time of applicability value is reset to zero at every midnight. 2. The time of applicability indicates the exact time at which the position transmitted in the target report is valid.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="072" rule="optional">
+        <DataItemName>Time of Applicability for Velocity</DataItemName>
+        <DataItemDefinition>Time of applicability (measurement) of the reported velocity, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_applicability_velocity</BitsShortName>
+                    <BitsName>Time of Applicability of Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. The time of applicability value is reset to zero at every midnight. 2. The time of applicability indicates the exact time at which the velocity information transmitted in the target report is valid. 3. This item will not be available in some ADS-B technologies.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="073" rule="optional">
+        <DataItemName>Time of Message Reception for Position</DataItemName>
+        <DataItemDefinition>Time of reception of the latest position squitter in the Ground Station, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_reception_position</BitsShortName>
+                    <BitsName>Time of Message Reception of Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of message reception value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="074" rule="optional">
+        <DataItemName>Time of Message Reception of Position-High Precision</DataItemName>
+        <DataItemDefinition>Time at which the latest ADS-B position information was received by the ground station, expressed as fraction of the second of the UTC Time.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRp whole seconds = (I021/073) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRp whole seconds = (I021/073) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRp whole seconds = (I021/073) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1">
+                    <BitsShortName>time_reception_position_highprecision</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for position in the ground station.</BitsName>
+                    <BitsUnit scale="0.9313225746154785">ns</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="075" rule="optional">
+        <DataItemName>Time of Message Reception for Velocity</DataItemName>
+        <DataItemDefinition>Time of reception of the latest velocity squitter in the Ground Station, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_reception_velocity</BitsShortName>
+                    <BitsName>Time of Message Reception of Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of message reception value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="076" rule="optional">
+        <DataItemName>Time of Message Reception of Velocity-High Precision</DataItemName>
+        <DataItemDefinition>Time at which the latest ADS-B velocity information was received by the ground station, expressed as fraction of the second of the UTC Time.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRv whole seconds = (I021/073) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRv whole seconds = (I021/073) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRv whole seconds = (I021/073) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1">
+                    <BitsShortName>time_reception_velocity_highprecision</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for velocity in the ground station.</BitsName>
+                    <BitsUnit scale="0.9313225746154785">ns</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="077" rule="optional">
+        <DataItemName>Time of ASTERIX Report Transmission</DataItemName>
+        <DataItemDefinition>Time of the transmission of the ASTERIX category 021 report in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_report_transmission</BitsShortName>
+                    <BitsName>Time of ASTERIX Report Transmission</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of ASTERIX report transmission value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="080" rule="mandatory">
+        <DataItemName>Target Address</DataItemName>
+        <DataItemDefinition>Target address (emitter identifier) assigned uniquely to each target.</DataItemDefinition>
+        <DataItemFormat desc="Three-octet fixed length Data Item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+					<BitsShortName>TAddr</BitsShortName>
+                    <BitsName>Target Address</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="090" rule="mandatory">
+        <DataItemName>Quality Indicators</DataItemName>
+        <DataItemDefinition>ADS-B quality indicators transmitted by a/c according to MOPS version.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one- octet, followed by one-octet extents as necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>NUCr_or_NACv</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for velocity or Navigation Accuracy Category for Velocity</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NUCp_or_NIC</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for Position NUCp or Navigation Integrity Category NIC.</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>NICbaro</BitsShortName>
+                        <BitsName>Navigation Integrity Category for Barometric Altitude</BitsName>
+                    </Bits>
+                    <Bits from="7" to="6">
+                        <BitsShortName>SIL</BitsShortName>
+                        <BitsName>Surveillance Integrity Level</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NACp</BitsShortName>
+                        <BitsName>Navigation Accuracy Category for Position</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SILS</BitsShortName>
+                        <BitsName>Surveillance Integrity Level-Supplement</BitsName>
+                        <BitsValue val="0">measured per flight-hour</BitsValue>
+                        <BitsValue val="1">measured per sample</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>SDA</BitsShortName>
+                        <BitsName>Horizontal Position System Design Assurance Level</BitsName>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>GVA</BitsShortName>
+                        <BitsName>Geometric Altitude Accuracy</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>PIC</BitsShortName>
+                        <BitsName>Position Integrity Category</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="110" rule="optional">
+        <DataItemName>Trajectory Intent</DataItemName>
+        <DataItemDefinition>Reports indicating the 4D intended trajectory of the aircraft.</DataItemDefinition>
+        <DataItemFormat desc="Compound Data Item, comprising a primary subfield of one octet, followed by the indicated subfields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>TIS_presence</BitsShortName>
+                            <BitsName>Trajectory Intent Status presence</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TID_presence</BitsShortName>
+                            <BitsName>Trajectory Intent Data prsence</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+                            <BitsValue val="0">End of Data Item</BitsValue>
+                            <BitsValue val="1">Extension into next extent</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>NAV</BitsShortName>
+                            <BitsName>NAV</BitsName>
+                            <BitsValue val="0">Trajectory Intent Data is available for this aircraft</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not available for this aircraft</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>NVB</BitsShortName>
+                            <BitsName>NVB</BitsName>
+                            <BitsValue val="0">Trajectory Intent Data is valid</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not valid</BitsValue>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+                            <BitsValue val="0">End of Data Item</BitsValue>
+                            <BitsValue val="1">Extension into next extent</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Repetitive>
+                    <Fixed length="15">
+                        <Bits bit="120">
+                            <BitsShortName>TCA</BitsShortName>
+                            <BitsValue val="0">TCP number available</BitsValue>
+                            <BitsValue val="1">TCP number not available</BitsValue>
+                        </Bits>
+                        <Bits bit="119">
+                            <BitsShortName>NC</BitsShortName>
+                            <BitsValue val="0">TCP compliance</BitsValue>
+                            <BitsValue val="1">TCP non-compliance</BitsValue>
+                        </Bits>
+                        <Bits from="118" to="113">
+							<BitsShortName>TcpN</BitsShortName>
+                            <BitsName>Trajectory Change Point Number</BitsName>
+                        </Bits>
+                        <Bits from="112" to="97" encode="signed">
+							<BitsShortName>Alt</BitsShortName>
+                            <BitsName>Altitude</BitsName>
+                            <BitsUnit scale="10" min="-1500" max="150000">ft</BitsUnit>
+                        </Bits>
+                        <Bits from="96" to="73" encode="signed">
+							<BitsShortName>Lat</BitsShortName>
+                            <BitsName>Latitude</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="72" to="49" encode="signed">
+							<BitsShortName>Lon</BitsShortName>
+                            <BitsName>Longitude</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-180" max="180">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="48" to="45">
+							<BitsShortName>PType</BitsShortName>
+                            <BitsName>Point Type</BitsName>
+                            <BitsValue val="0">Unknown</BitsValue>
+                            <BitsValue val="1">Fly by waypoint (LT)</BitsValue>
+                            <BitsValue val="2">Fly over waypoint (LT)</BitsValue>
+                            <BitsValue val="3">Hold pattern (LT)</BitsValue>
+                            <BitsValue val="4">Procedure hold (LT)</BitsValue>
+                            <BitsValue val="5">Procedure turn (LT)</BitsValue>
+                            <BitsValue val="6">RF leg (LT)</BitsValue>
+                            <BitsValue val="7">Top of climb (VT)</BitsValue>
+                            <BitsValue val="8">Top of descent (VT)</BitsValue>
+                            <BitsValue val="9">Start of level (VT)</BitsValue>
+                            <BitsValue val="10">Cross-over altitude (VT)</BitsValue>
+                            <BitsValue val="11">Transition altitude (VT)</BitsValue>
+                        </Bits>
+                        <Bits from="44" to="43">
+                            <BitsShortName>TD</BitsShortName>
+                            <BitsValue val="0">N/A</BitsValue>
+                            <BitsValue val="1">Turn right</BitsValue>
+                            <BitsValue val="2">Turn left</BitsValue>
+                            <BitsValue val="3">No turn</BitsValue>
+                        </Bits>
+                        <Bits bit="42">
+                            <BitsShortName>TRA</BitsShortName>
+                            <BitsName>Turn Radius Availability</BitsName>
+                            <BitsValue val="0">TTR not available</BitsValue>
+                            <BitsValue val="1">TTR available</BitsValue>
+                        </Bits>
+                        <Bits bit="41">
+                            <BitsShortName>TOA</BitsShortName>
+                            <BitsValue val="0">TOV available</BitsValue>
+                            <BitsValue val="1">TOV not available</BitsValue>
+                        </Bits>
+                        <Bits from="40" to="17">
+                            <BitsShortName>TOV</BitsShortName>
+                            <BitsName>Time Over Point</BitsName>
+                            <BitsUnit scale="1">s</BitsUnit>
+                        </Bits>
+                        <Bits from="16" to="1">
+                            <BitsShortName>TTR</BitsShortName>
+                            <BitsName>TCP Turn radius</BitsName>
+                            <BitsUnit scale="0.01" max="655.35">Nm</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                </Repetitive>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="130" rule="optional">
+        <DataItemName>Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>Position in WGS-84 Co-ordinates.</DataItemDefinition>
+        <DataItemFormat desc="Six-octet fixed length Data Item.">
+            <Fixed length="6">
+                <Bits from="48" to="25" encode="signed">
+					<BitsShortName>Lat</BitsShortName>
+					<BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                </Bits>
+                <Bits from="24" to="1" encode="signed">
+					<BitsShortName>Lon</BitsShortName>
+					<BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="131" rule="optional">
+        <DataItemName>High-Resolution Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>Position in WGS-84 Co-ordinates in high resolution.</DataItemDefinition>
+        <DataItemFormat desc="Eight-octet fixed length Data Item.">
+            <Fixed length="8">
+                <Bits from="64" to="33" encode="signed">
+					<BitsShortName>Lat</BitsShortName>
+					<BitsName>Latitude In WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
+                </Bits>
+                <Bits from="32" to="1" encode="signed">
+					<BitsShortName>Lon</BitsShortName>
+                    <BitsName>Longitude In WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="132" rule="optional">
+        <DataItemName>Message Amplitude</DataItemName>
+        <DataItemDefinition>Amplitude, in dBm, of ADS-B messages received by the ground station, coded in two's complement.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1" encode="signed">
+                    <BitsShortName>MAM</BitsShortName>
+                    <BitsName>Message Amplitude</BitsName>
+                    <BitsUnit scale="1">dBm</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="140" rule="optional">
+        <DataItemName>Geometric Height</DataItemName>
+        <DataItemDefinition>Minimum height from a plane tangent to the earth's ellipsoid, defined by WGS-84, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>geometric_height</BitsShortName>
+                    <BitsName>Geometric Height</BitsName>
+                    <BitsUnit scale="6.25" min="-1500" max="150000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="145" rule="optional">
+        <DataItemName>Flight Level</DataItemName>
+        <DataItemDefinition>Flight Level from barometric measurements, not QNH corrected, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+					<BitsShortName>FL</BitsShortName>
+                    <BitsName>Flight Level</BitsName>
+                    <BitsUnit scale="0.25" min="-15" max="1500">FL</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="146" rule="optional">
+        <DataItemName>Intermediate State Selected Altitude</DataItemName>
+        <DataItemDefinition>The short-term vertical intent as described by either the FMS selected altitude, the Altitude Control Panel Selected Altitude, or the current aircraft altitude according to the aircraft's mode of flight.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>SAS</BitsShortName>
+                    <BitsName>Source Availability</BitsName>
+                    <BitsValue val="0">No source information provided</BitsValue>
+                    <BitsValue val="1">Source Information provided</BitsValue>
+                </Bits>
+                <Bits from="15" to="14">
+                    <BitsShortName>Source</BitsShortName>
+                    <BitsName>Source</BitsName>
+                    <BitsValue val="0">Unknown</BitsValue>
+                    <BitsValue val="1">Aircraft Altitude (Holding Altitude)</BitsValue>
+                    <BitsValue val="2">FCU/MCP Selected Altitude</BitsValue>
+                    <BitsValue val="3">FMS Selected Altitude</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+					<BitsShortName>Alt</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="148" rule="optional">
+        <DataItemName>Final State Selected Altitude</DataItemName>
+        <DataItemDefinition>The vertical intent value that corresponds with the ATC cleared altitude, as derived from the Altitude Control Panel (FCU/MCP).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>MV</BitsShortName>
+                    <BitsName>Manage Vertical Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="15">
+                    <BitsShortName>AH</BitsShortName>
+                    <BitsName>Altitude Hold Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="14">
+                    <BitsShortName>AM</BitsShortName>
+                    <BitsName>Approach Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+					<BitsShortName>Alt</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="150" rule="optional">
+        <DataItemName>Air Speed</DataItemName>
+        <DataItemDefinition>Calculated Air Speed (Element of Air Vector).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>IM</BitsShortName>
+                    <BitsName>Air Speed type</BitsName>
+                    <BitsValue val="0">Air Speed = IAS</BitsValue>
+                    <BitsValue val="1">Air Speed = Mach</BitsValue>
+                </Bits>
+                <Bits from="15" to="1">
+					<BitsShortName>ASpeed</BitsShortName>
+                    <BitsName>Air Speed (IAS or Mach)</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="151" rule="optional">
+        <DataItemName>True Air Speed</DataItemName>
+        <DataItemDefinition>True Air Speed.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1">
+					<BitsShortName>TAS</BitsShortName>
+                    <BitsName>True Air Speed</BitsName>
+                    <BitsUnit scale="1">knot</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the True Air Speed contains the maximum value that can be downloaded from the aircraft avionics and the RE- bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="152" rule="optional">
+        <DataItemName>Magnetic Heading</DataItemName>
+        <DataItemDefinition>Magnetic Heading (Element of Air Vector).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1">
+					<BitsShortName>MHdg</BitsShortName>
+                    <BitsName>Magnetic Heading</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="155" rule="optional">
+        <DataItemName>Barometric Vertical Rate</DataItemName>
+        <DataItemDefinition>Barometric Vertical Rate, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+					<BitsShortName>BVR</BitsShortName>
+                    <BitsName>Barometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/minute</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Barometric Vertical Rate contains the maximum value that can be downloaded from the aircraft avionics and the RE-bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="157" rule="optional">
+        <DataItemName>Geometric Vertical Rate</DataItemName>
+        <DataItemDefinition>Geometric Vertical Rate, in two's complement form, with reference to WGS-84.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+					<BitsShortName>GVR</BitsShortName>
+                    <BitsName>Geometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/minute</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Geometric Vertical Rate contains the maximum value that can be downloaded from the aircraft avionics and the RE-bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="160" rule="optional">
+        <DataItemName>Ground Vector</DataItemName>
+        <DataItemDefinition>Ground Speed and Track Angle elements of Ground Vector.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits bit="32">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="31" to="17">
+					<BitsShortName>GS</BitsShortName>
+                    <BitsName>Ground Speed referenced to WGS-84</BitsName>
+                    <BitsUnit scale="0.00006103515625">NM/s</BitsUnit>
+                </Bits>
+                <Bits from="16" to="1">
+					<BitsShortName>TA</BitsShortName>
+                    <BitsName>Track Angle clockwise reference to True North</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Ground Speed contains the maximum value that can be downloaded from the aircraft avionics and the RE- bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="161" rule="optional">
+        <DataItemName>Track Number</DataItemName>
+        <DataItemDefinition>An integer value representing a unique reference to a track record within a particular track file.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1">
+					<BitsShortName>TrackN</BitsShortName>
+                    <BitsName>Track number</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="165" rule="optional">
+        <DataItemName>Track Angle Rate</DataItemName>
+        <DataItemDefinition>Rate of Turn, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="2-Byte Fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="11">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="10" to="1">
+					<BitsShortName>TA_rate</BitsShortName>
+                    <BitsName>Track Angle Rate</BitsName>
+                    <BitsUnit scale="0.03125">deg/s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="170" rule="optional">
+        <DataItemName>Target Identification</DataItemName>
+        <DataItemDefinition>Target (aircraft or vehicle) identification in 8 characters, as reported by the target.</DataItemDefinition>
+        <DataItemFormat desc="Six-octet fixed length Data Item.">
+            <Fixed length="6">
+                <Bits from="48" to="1" encode="6bitschar">
+					<BitsShortName>TId</BitsShortName>
+                    <BitsName>Characters 1-8 (coded on 6 Bits each) defining target identification when flight plan is available or the registration marking when no flight plan is available. Coding rules are provided in [6] Section 3.1.2.9.1.2 and Table 3-9.</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="200" rule="optional">
+        <DataItemName>Target Status</DataItemName>
+        <DataItemDefinition>Status of the target</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>ICF</BitsShortName>
+                    <BitsName>Intent Change Flag</BitsName>
+                    <BitsValue val="0">No intent change active</BitsValue>
+                    <BitsValue val="1">Intent change flag raised</BitsValue>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>LNAV</BitsShortName>
+                    <BitsName>LNAV Mode</BitsName>
+                    <BitsValue val="0">LNAV Mode engaged</BitsValue>
+                    <BitsValue val="1">LNAV Mode not engaged</BitsValue>
+                </Bits>
+                <Bits bit="6">
+                    <BitsShortName>ME</BitsShortName>
+                    <BitsName>Military Emergency</BitsName>
+                    <BitsValue val="0">No Military Emergency</BitsValue>
+                    <BitsValue val="1">Military Emergency</BitsValue>
+                </Bits>
+                <Bits from="5" to="3">
+                    <BitsShortName>PS</BitsShortName>
+                    <BitsName>Priority Status</BitsName>
+                    <BitsValue val="0">No emergency / not reported</BitsValue>
+                    <BitsValue val="1">General emergency</BitsValue>
+                    <BitsValue val="2">Lifeguard / medical emergency</BitsValue>
+                    <BitsValue val="3">Minimum fuel</BitsValue>
+                    <BitsValue val="4">No communications</BitsValue>
+                    <BitsValue val="5">Unlawful interference</BitsValue>
+                    <BitsValue val="6">Downed Aircraft</BitsValue>
+                </Bits>
+                <Bits from="2" to="1">
+                    <BitsShortName>SS</BitsShortName>
+                    <BitsName>Surveillance Status</BitsName>
+                    <BitsValue val="0">No condition reported</BitsValue>
+                    <BitsValue val="1">Permanent Alert (Emergency condition)</BitsValue>
+                    <BitsValue val="2">Temporary Alert (change in Mode 3/A Code other than emergency)</BitsValue>
+                    <BitsValue val="3">SPI set</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Bit 8 (ICF), when set to 1 indicates that new information is available in the Mode S GICB registers 40, 41 or 42.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="210" rule="optional">
+        <DataItemName>MOPS Version</DataItemName>
+        <DataItemDefinition>Identification of the MOPS version used by a/c to supply ADS-B information.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>VNS</BitsShortName>
+                    <BitsName>Version Not Supported</BitsName>
+                    <BitsValue val="0">The MOPS Version is supported by the GS</BitsValue>
+                    <BitsValue val="1">The MOPS Version is not supported by the GS</BitsValue>
+                </Bits>
+                <Bits from="6" to="4">
+                    <BitsShortName>VN</BitsShortName>
+                    <BitsName>Version Number</BitsName>
+                    <BitsValue val="0">DO-260 [Ref. 8]</BitsValue>
+                    <BitsValue val="1">DO-260A [Ref. 9]</BitsValue>
+                    <BitsValue val="2">DO-260B</BitsValue>
+                </Bits>
+                <Bits from="3" to="1">
+                    <BitsShortName>LTT</BitsShortName>
+                    <BitsName>Link Technology Type</BitsName>
+                    <BitsValue val="0">Other</BitsValue>
+                    <BitsValue val="1">UAT</BitsValue>
+                    <BitsValue val="2">1090 ES</BitsValue>
+                    <BitsValue val="3">VDL 4</BitsValue>
+                    <BitsValue val="4">Not assigned</BitsValue>
+                    <BitsValue val="5">Not assigned</BitsValue>
+                    <BitsValue val="6">Not assigned</BitsValue>
+                    <BitsValue val="7">Not assigned</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Bit 7 (VNS) when set to 1 indicates that the aircraft transmits a MOPS Version indication that is not supported by the Ground Station. However, since MOPS versions are supposed to be backwards compatible, the GS has attempted to interpret the message and achieved a credible result. The fact that the MOPS version received is not supported by the GS is submitted as additional information to subsequent processing systems.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="220" rule="optional">
+        <DataItemName>Met Information</DataItemName>
+        <DataItemDefinition>Meteorological information.</DataItemDefinition>
+        <DataItemFormat desc="Compound data item consisting of a one byte primary sub-field, followed by up to four fixed length data fields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>WS_presence</BitsShortName>
+                            <BitsName>Wind speed presence</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>WD_presence</BitsShortName>
+                            <BitsName>Wind Direction presence</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TMP_presence</BitsShortName>
+                            <BitsName>Temperature presence</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TRB_presence</BitsShortName>
+                            <BitsName>Turbulence presence</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits from="4" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                    <Fixed length="2">
+                        <Bits from="16" to="1">
+						<BitsShortName>WindS</BitsShortName>
+                            <BitsName>Wind Speed</BitsName>
+                            <BitsUnit scale="1" max="300">knot</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits from="16" to="1">
+						<BitsShortName>WindD</BitsShortName>
+                            <BitsName>Wind Direction</BitsName>
+                            <BitsUnit scale="1" min="1" max="360">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits from="16" to="1" encode="signed">
+						<BitsShortName>Temp</BitsShortName>
+                            <BitsName>Temperature</BitsName>
+                            <BitsUnit scale="0.25" min="-100" max="100">C</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="8" to="1">
+						<BitsShortName>Turb</BitsShortName>
+						<BitsName>Turbulence</BitsName>
+                        </Bits>
+                    </Fixed>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="230" rule="optional">
+        <DataItemName>Roll Angle</DataItemName>
+        <DataItemDefinition>The roll angle, in two's complement form, of an aircraft executing a turn.</DataItemDefinition>
+        <DataItemFormat desc="A two byte fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+					<BitsShortName>RollA</BitsShortName>
+                    <BitsName>Roll Angle</BitsName>
+                    <BitsUnit scale="0.01" min="-180" max="180">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. Negative Value indicates “Left Wing Down”. 2. Resolution provided by the technology “1090 MHz Extended Squitter” is 1 degree.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="250" rule="mandatory">
+        <DataItemName>Mode S MB Data</DataItemName>
+        <DataItemDefinition>Mode S Comm B data as extracted from the aircraft transponder.</DataItemDefinition>
+        <DataItemFormat desc="Repetitive Data Item starting with a one-octet Field Repetition Indicator (REP) followed by at least one BDS message comprising one seven octet BDS register and one octet BDS code.">
+            <Repetitive>
+                <Fixed length="8">
+                    <Bits from="64" to="9">
+                        <BitsShortName>MB</BitsShortName>
+                        <BitsName>(MB Data) 56-bit message conveying Mode S Comm B message data</BitsName>
+                    </Bits>
+                    <Bits from="8" to="5">
+                        <BitsShortName>BDS1</BitsShortName>
+                        <BitsName>Comm B Data Buffer Store 1 Address</BitsName>
+                    </Bits>
+                    <Bits from="4" to="1">
+                        <BitsShortName>BDS2</BitsShortName>
+                        <BitsName>Comm B Data Buffer Store 2 Address</BitsName>
+                    </Bits>
+                </Fixed>
+            </Repetitive>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="260" rule="mandatory">
+        <DataItemName>ACAS Resolution Advisory Report</DataItemName>
+        <DataItemDefinition>Currently active Resolution Advisory (RA), if any, generated by the ACAS associated with the transponder transmitting the RA message and threat identity data.</DataItemDefinition>
+        <DataItemFormat desc="Seven-octet fixed length Data Item.">
+            <Fixed length="7">
+                <Bits from="56" to="52">
+                    <BitsShortName>TYP</BitsShortName>
+                    <BitsName>Message Type</BitsName>
+                </Bits>
+                <Bits from="51" to="49">
+                    <BitsShortName>STYP</BitsShortName>
+                    <BitsName>Message Sub-Type</BitsName>
+                </Bits>
+                <Bits from="48" to="35">
+                    <BitsShortName>ARA</BitsShortName>
+                    <BitsName>Active Resolution Advisories</BitsName>
+                </Bits>
+                <Bits from="34" to="31">
+                    <BitsShortName>RAC</BitsShortName>
+                    <BitsName>RA complement record</BitsName>
+                </Bits>
+                <Bits bit="30">
+                    <BitsShortName>RAT</BitsShortName>
+                    <BitsName>RA Terminated</BitsName>
+                </Bits>
+                <Bits bit="29">
+                    <BitsShortName>MTE</BitsShortName>
+                    <BitsName>Multiple Threat Encounter</BitsName>
+                </Bits>
+                <Bits from="28" to="27">
+                    <BitsShortName>TTI</BitsShortName>
+                    <BitsName>Threat type indicator</BitsName>
+                </Bits>
+                <Bits from="26" to="1">
+                    <BitsShortName>TID</BitsShortName>
+                    <BitsName>Threat identity indicator</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="271" rule="optional">
+        <DataItemName>Surface Capabilities and Characteristics</DataItemName>
+        <DataItemDefinition>Operational capabilities of the aircraft while on the ground.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one-octet, followed by an one-octet extents if necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to zero</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>POA</BitsShortName>
+                        <BitsName>Position Offset Applied</BitsName>
+                        <BitsValue val="0">Position transmitted is not ADS-B position reference point</BitsValue>
+                        <BitsValue val="1">Position transmitted is the ADS-B position reference point</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>CDTI_S</BitsShortName>
+                        <BitsName>Cockpit Display of Traffic Information Surface</BitsName>
+                        <BitsValue val="0">CDTI not operational</BitsValue>
+                        <BitsValue val="1">CDTI operational</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>B2_low</BitsShortName>
+                        <BitsName>Class B2 transmit power less than 70 Watts</BitsName>
+                        <BitsValue val="0">&gt;= 70 Watts</BitsValue>
+                        <BitsValue val="1">&lt; 70 Watts</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RAS</BitsShortName>
+                        <BitsName>Receiving ATC Services</BitsName>
+                        <BitsValue val="0">Aircraft not receiving ATC-services</BitsValue>
+                        <BitsValue val="1">Aircraft receiving ATC services</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>IDENT</BitsShortName>
+                        <BitsName>Setting of “IDENT”-switch</BitsName>
+                        <BitsValue val="0">IDENT switch not active</BitsValue>
+                        <BitsValue val="1">IDENT switch active</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>FX Extension indicator</BitsName>
+                        <BitsValue val="0">no extension</BitsValue>
+                        <BitsValue val="1">extension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>length_width</BitsShortName>
+                        <BitsName>Length and width of the aircraft</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to zero</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>FX Extension indicator</BitsName>
+                        <BitsValue val="0">no extension</BitsValue>
+                        <BitsValue val="1">extension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="295" rule="optional">
+        <DataItemName>Data Ages</DataItemName>
+        <DataItemDefinition>Ages of the data provided.</DataItemDefinition>
+        <DataItemFormat desc="Compound Data Item, comprising a primary subfield of up to five octets, followed by the indicated subfields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>AOS_presence</BitsShortName>
+                            <BitsName>Aircraft Operational Status age presence</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TRD_presence</BitsShortName>
+                            <BitsName>arget Report Descriptor age presence</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>M3A_presence</BitsShortName>
+                            <BitsName>Mode 3/A Code age presence</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>QI_presence</BitsShortName>
+                            <BitsName>Quality Indicators age presence</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TI_presence</BitsShortName>
+                            <BitsName>Trajectory Intent age presence</BitsName>
+                            <BitsPresence>5</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MAM_presence</BitsShortName>
+                            <BitsName>Message Amplitude age presence</BitsName>
+                            <BitsPresence>6</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>GH_presence</BitsShortName>
+                            <BitsName>Geometric Height age presence</BitsName>
+                            <BitsPresence>7</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>FL_presence</BitsShortName>
+                            <BitsName>Flight Level age presence</BitsName>
+                            <BitsPresence>8</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>ISA_presence</BitsShortName>
+                            <BitsName>Intermediate State Selected Altitude age presence</BitsName>
+                            <BitsPresence>9</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>FSA_presence</BitsShortName>
+                            <BitsName>Final State Selected Altitude age presence</BitsName>
+                            <BitsPresence>10</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>AS_presence</BitsShortName>
+                            <BitsName>Air Speed age presence</BitsName>
+                            <BitsPresence>11</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TAS_presence</BitsShortName>
+                            <BitsName>True Air Speed age presence</BitsName>
+                            <BitsPresence>12</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MH_presence</BitsShortName>
+                            <BitsName>Magnetic Heading age presence</BitsName>
+                            <BitsPresence>13</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>BVR_presence</BitsShortName>
+                            <BitsName>Barometric Vertical Rate age presence</BitsName>
+                            <BitsPresence>14</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>GVR_presence</BitsShortName>
+                            <BitsName>Geometric Vertical Rate age presence</BitsName>
+                            <BitsPresence>15</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>GV_presence</BitsShortName>
+                            <BitsName>Ground Vector age presence</BitsName>
+                            <BitsPresence>16</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TAR_presence</BitsShortName>
+                            <BitsName>Track Angle Rate age presence</BitsName>
+                            <BitsPresence>17</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TI_presence</BitsShortName>
+                            <BitsName>Target Identification age presence</BitsName>
+                            <BitsPresence>18</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TS_presence</BitsShortName>
+                            <BitsName>Target Status age presence</BitsName>
+                            <BitsPresence>19</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MET_presence</BitsShortName>
+                            <BitsName>Met Information age presence</BitsName>
+                            <BitsPresence>20</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>ROA_presence</BitsShortName>
+                            <BitsName>Roll Angle age presence</BitsName>
+                            <BitsPresence>21</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>ARA_presence</BitsShortName>
+                            <BitsName>ACAS Resolution Advisory age age presence</BitsName>
+                            <BitsPresence>22</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>SCC_presence</BitsShortName>
+                            <BitsName>Surface Capabilities and Characteristics age presence</BitsName>
+                            <BitsPresence>23</BitsPresence>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>AOS</BitsShortName>
+                        <BitsName>Age of the latest received information transmitted in item I021/008.</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TRD</BitsShortName>
+                        <BitsName>Age of the last update of the Target Report Descriptor, item I021/040</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>M3A</BitsShortName>
+                        <BitsName>Age of the last update of the Mode 3/A Code, item I021/070</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>QI</BitsShortName>
+                        <BitsName>Age of the latest information received to update the Quality Indicators, item I021/090</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TI</BitsShortName>
+                        <BitsName>Age of the last update of the Trajectory Intent information updating item I021/110</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MAM</BitsShortName>
+                        <BitsName>Age of the latest measurement of the message amplitude, item I021/132</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GH</BitsShortName>
+                        <BitsName>Age of the information contained in item 021/140</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>FL</BitsShortName>
+                        <BitsName>Age of the Flight Level information in item I021/145</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ISA</BitsShortName>
+                        <BitsName>Age of the Intermediate State Selected Altitude in item I021/146</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>FSA</BitsShortName>
+                        <BitsName>Age of the Final State Selected Altitude in item I021/148</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>AS</BitsShortName>
+                        <BitsName>Age of the Air Speed contained in item I021/150</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TAS</BitsShortName>
+                        <BitsName>Age of the value for the True Air Speed in item I021/151</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MH</BitsShortName>
+                        <BitsName>Age of the value for the Magnetic Heading in item I021/152</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>BVR</BitsShortName>
+                        <BitsName>Age of the Barometric Vertical Rate contained in I021/155</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GVR</BitsShortName>
+                        <BitsName>Age of the Geometric Vertical Rate in item I021/157</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GV</BitsShortName>
+                        <BitsName>Age of the Ground Vector in item I021/160</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TAR</BitsShortName>
+                        <BitsName>Age of item I021/165 Track Angle Rate</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TI</BitsShortName>
+                        <BitsName>Age of the Target Identification in item I021/170</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TS</BitsShortName>
+                        <BitsName>Age of the Target Status as contained in item I021/200</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MET</BitsShortName>
+                        <BitsName>Age of the Meteorological data contained in I021/220</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ROA</BitsShortName>
+                        <BitsName>Age of the Roll Angle value as in item I021/230</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ARA</BitsShortName>
+                        <BitsName>Age of the latest update of an active ACAS Resolution Advisory</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>SCC</BitsShortName>
+                        <BitsName>Age of the latest information received on the surface capabilities and characteristics of the respective target</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+            </Compound>
+        </DataItemFormat>
+        <DataItemNote>1. In all the subfields, the age is the time delay since the latest update received from the target. 2. In all the subfields, the maximum value indicates “maximum value or above”.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="400" rule="optional">
+        <DataItemName>Receiver ID</DataItemName>
+        <DataItemDefinition>Designator of Ground Station in Distributed System.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>RID</BitsShortName>
+                    <BitsName>Receiver ID</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="RE" rule="optional">
+        <DataItemName>Reserved Expansion</DataItemName>
+        <DataItemDefinition>Reserved information</DataItemDefinition>
+        <DataItemFormat desc="Explicit data length item">
+            <Explicit>
+                <Repetitive>
+                    <Fixed length="1">
+                        <Bits from="8" to="1">
+                            <BitsShortName>REval</BitsShortName>
+                        </Bits>
+                    </Fixed>  
+                </Repetitive>       
+            </Explicit>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="SP" rule="optional">
+        <DataItemName>Special Purpose</DataItemName>
+        <DataItemDefinition>Special information</DataItemDefinition>
+        <DataItemFormat desc="Explicit data length item">
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+						<BitsShortName>SPval</BitsShortName>
+                    </Bits>
+                </Fixed>         
+            </Explicit>
+        </DataItemFormat>
+    </DataItem>
+
+    <UAP>
+        <UAPItem bit="0" frn="1" len="2">010</UAPItem>
+        <UAPItem bit="1" frn="2" len="2+">040</UAPItem>
+        <UAPItem bit="2" frn="3" len="2">161</UAPItem>
+        <UAPItem bit="3" frn="4" len="1">015</UAPItem>
+        <UAPItem bit="4" frn="5" len="3">071</UAPItem>
+        <UAPItem bit="5" frn="6" len="6">130</UAPItem>
+        <UAPItem bit="6" frn="7" len="8">131</UAPItem>
+        <UAPItem bit="7" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="8" frn="8" len="3">072</UAPItem>
+        <UAPItem bit="9" frn="9" len="2">150</UAPItem>
+        <UAPItem bit="10" frn="10" len="2">151</UAPItem>
+        <UAPItem bit="11" frn="11" len="3">080</UAPItem>
+        <UAPItem bit="12" frn="12" len="3">073</UAPItem>
+        <UAPItem bit="13" frn="13" len="4">074</UAPItem>
+        <UAPItem bit="14" frn="14" len="3">075</UAPItem>
+        <UAPItem bit="15" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="16" frn="15" len="4">076</UAPItem>
+        <UAPItem bit="17" frn="16" len="2">140</UAPItem>
+        <UAPItem bit="18" frn="17" len="1+">090</UAPItem>
+        <UAPItem bit="19" frn="18" len="1">210</UAPItem>
+        <UAPItem bit="20" frn="19" len="2">070</UAPItem>
+        <UAPItem bit="21" frn="20" len="2">230</UAPItem>
+        <UAPItem bit="22" frn="21" len="2">145</UAPItem>
+        <UAPItem bit="23" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="24" frn="22" len="2">152</UAPItem>
+        <UAPItem bit="25" frn="23" len="1">200</UAPItem>
+        <UAPItem bit="26" frn="24" len="2">155</UAPItem>
+        <UAPItem bit="27" frn="25" len="2">157</UAPItem>
+        <UAPItem bit="28" frn="26" len="4">160</UAPItem>
+        <UAPItem bit="29" frn="27" len="2">165</UAPItem>
+        <UAPItem bit="30" frn="28" len="3">077</UAPItem>
+        <UAPItem bit="31" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="32" frn="29" len="6">170</UAPItem>
+        <UAPItem bit="33" frn="30" len="1">020</UAPItem>
+        <UAPItem bit="34" frn="31" len="1+">220</UAPItem>
+        <UAPItem bit="35" frn="32" len="2">146</UAPItem>
+        <UAPItem bit="36" frn="33" len="2">148</UAPItem>
+        <UAPItem bit="37" frn="34" len="1+">110</UAPItem>
+        <UAPItem bit="38" frn="35" len="1">016</UAPItem>
+        <UAPItem bit="39" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="40" frn="36" len="1">008</UAPItem>
+        <UAPItem bit="41" frn="37" len="1+">271</UAPItem>
+        <UAPItem bit="42" frn="38" len="1">132</UAPItem>
+        <UAPItem bit="43" frn="39" len="1+N*8">250</UAPItem>
+        <UAPItem bit="44" frn="40" len="7">260</UAPItem>
+        <UAPItem bit="45" frn="41" len="1">400</UAPItem>
+        <UAPItem bit="46" frn="42" len="1+">295</UAPItem>
+        <UAPItem bit="47" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="48" frn="43" len="-">-</UAPItem>
+        <UAPItem bit="49" frn="44" len="-">-</UAPItem>
+        <UAPItem bit="50" frn="45" len="-">-</UAPItem>
+        <UAPItem bit="51" frn="46" len="-">-</UAPItem>
+        <UAPItem bit="52" frn="47" len="-">-</UAPItem>
+        <UAPItem bit="53" frn="48" len="1+">RE</UAPItem>
+        <UAPItem bit="54" frn="49" len="1+">SP</UAPItem>
+        <UAPItem bit="55" frn="FX" len="-">-</UAPItem>
+    </UAP>
+
+</Category>


### PR DESCRIPTION
I've provided a definition for CAT021 v2.2 from [documentation here](https://www.eurocontrol.int/sites/default/files/content/documents/nm/asterix/20140807-asterix-adsbm-part12-v2.2.pdf).
Corrected a bit definition error in the previous v1.8 CAT021 definition file
Implemented a function to handle explicit length fields. I'm not sure if this will have an impact on other Asterix categories but for CAT021 messages the lack of this function was causing spurious and erroneous records to be created with the remaining bytes in the reserved and special fields.